### PR TITLE
add dynamic topic modeling to clustering models

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -188,6 +188,11 @@ top2vec = ClusteringTopicModel(
 Theoretically the model descriptions above should result in the same behaviour as the other two packages, but there might be minor changes in implementation.
 We do not intend to keep up with changes in Top2Vec's and BERTopic's internal implementation details indefinitely.
 
+### _(Optional)_ 5. Dynamic Modeling
+
+Clustering models are also capable of dynamic topic modeling. This happens by fitting a clustering model over the entire corpus, as we expect that there is only one semantic model generating the documents.
+To gain temporal representations for topics, the corpus is divided into equal, or arbitrarily chosen time slices, and then term importances are estimated using Soft-c-TF-IDF, c-TF-IDF, or distances from cluster centroid for each of the time slices separately. When distance from cluster centroids is used to estimate topic importances in dynamic modeling, cluster centroids are computed based on documents and terms present within a given time slice.
+
 ## Considerations
 
 ### Strengths

--- a/docs/dynamic.md
+++ b/docs/dynamic.md
@@ -28,7 +28,7 @@ Dynamic topic models in Turftopic have a unified interface.
 To fit a dynamic topic model you will need a corpus, that has been annotated with timestamps.
 The timestamps need to be Python `datetime` objects, but pandas `Timestamp` object are also supported.
 
-Models that have dynamic modeling capabilities have a `fit_transform_dynamic()` method, that fits the model on the corpus over time.
+Models that have dynamic modeling capabilities (currently, `GMM` and `ClusteringTopicModel`) have a `fit_transform_dynamic()` method, that fits the model on the corpus over time.
 
 ```python
 from datetime import datetime

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,22 +13,22 @@ from turftopic import (
     AutoEncodingTopicModel,
     ClusteringTopicModel,
     KeyNMF,
-    SemanticSignalSeparation
+    SemanticSignalSeparation,
 )
 
 
 def generate_dates(
-        n_dates: int,
+    n_dates: int,
 ) -> list[datetime]:
-        """ Generate random dates to test dynamic models """
-        dates = []
-        for n in range(n_dates):
-             d = np.random.randint(low=1, high=29)
-             m = np.random.randint(low=1, high=13)
-             y = np.random.randint(low=2000, high=2020)
-             date = datetime(year=y, month=m, day=d)
-             dates.append(date)
-        return dates
+    """Generate random dates to test dynamic models"""
+    dates = []
+    for n in range(n_dates):
+        d = np.random.randint(low=1, high=29)
+        m = np.random.randint(low=1, high=13)
+        y = np.random.randint(low=2000, high=2020)
+        date = datetime(year=y, month=m, day=d)
+        dates.append(date)
+    return dates
 
 
 newsgroups = fetch_20newsgroups(
@@ -46,8 +46,8 @@ timestamps = generate_dates(n_dates=len(texts))
 models = [
     GMM(5, encoder=trf),
     SemanticSignalSeparation(5, encoder=trf),
-    KeyNMF(5, encoder=trf, keyword_scope='document'),
-    KeyNMF(5, encoder=trf, keyword_scope='corpus'),
+    KeyNMF(5, encoder=trf, keyword_scope="document"),
+    KeyNMF(5, encoder=trf, keyword_scope="corpus"),
     ClusteringTopicModel(
         n_reduce_to=5,
         feature_importance="c-tf-idf",
@@ -69,14 +69,14 @@ dynamic_models = [
         n_reduce_to=5,
         feature_importance="centroid",
         encoder=trf,
-        reduction_method="smallest"
+        reduction_method="smallest",
     ),
     ClusteringTopicModel(
         n_reduce_to=5,
         feature_importance="soft-c-tf-idf",
         encoder=trf,
         reduction_method="smallest"
-    )
+    ),
 ]
 
 
@@ -94,7 +94,9 @@ def test_fit_export_table(model):
 @pytest.mark.parametrize("model", dynamic_models)
 def test_fit_dynamic(model):
     doc_topic_matrix = model.fit_transform_dynamic(
-         texts, embeddings=embeddings, timestamps=timestamps,
+        texts,
+        embeddings=embeddings,
+        timestamps=timestamps,
     )
     table = model.export_topics(format="csv")
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import tempfile
 from pathlib import Path
 
@@ -12,8 +13,23 @@ from turftopic import (
     AutoEncodingTopicModel,
     ClusteringTopicModel,
     KeyNMF,
-    SemanticSignalSeparation,
+    SemanticSignalSeparation
 )
+
+
+def generate_dates(
+        n_dates: int,
+) -> list[datetime]:
+        """ Generate random dates to test dynamic models """
+        dates = []
+        for n in range(n_dates):
+             d = np.random.randint(low=1, high=29)
+             m = np.random.randint(low=1, high=13)
+             y = np.random.randint(low=2000, high=2020)
+             date = datetime(year=y, month=m, day=d)
+             dates.append(date)
+        return dates
+
 
 newsgroups = fetch_20newsgroups(
     subset="all",
@@ -25,6 +41,7 @@ newsgroups = fetch_20newsgroups(
 texts = newsgroups.data
 trf = SentenceTransformer("all-MiniLM-L6-v2")
 embeddings = np.asarray(trf.encode(texts))
+timestamps = generate_dates(n_dates=len(texts))
 
 models = [
     GMM(5, encoder=trf),
@@ -46,10 +63,39 @@ models = [
     AutoEncodingTopicModel(5, combined=True),
 ]
 
+dynamic_models = [
+    GMM(5, encoder=trf),
+    ClusteringTopicModel(
+        n_reduce_to=5,
+        feature_importance="centroid",
+        encoder=trf,
+        reduction_method="smallest"
+    ),
+    ClusteringTopicModel(
+        n_reduce_to=5,
+        feature_importance="soft-c-tf-idf",
+        encoder=trf,
+        reduction_method="smallest"
+    )
+]
+
 
 @pytest.mark.parametrize("model", models)
 def test_fit_export_table(model):
     doc_topic_matrix = model.fit_transform(texts, embeddings=embeddings)
+    table = model.export_topics(format="csv")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        out_path = Path(tmpdirname).joinpath("topics.csv")
+        with out_path.open("w") as out_file:
+            out_file.write(table)
+        df = pd.read_csv(out_path)
+
+
+@pytest.mark.parametrize("model", dynamic_models)
+def test_fit_dynamic(model):
+    doc_topic_matrix = model.fit_transform_dynamic(
+         texts, embeddings=embeddings, timestamps=timestamps,
+    )
     table = model.export_topics(format="csv")
     with tempfile.TemporaryDirectory() as tmpdirname:
         out_path = Path(tmpdirname).joinpath("topics.csv")

--- a/turftopic/base.py
+++ b/turftopic/base.py
@@ -23,7 +23,9 @@ Encoder = Union[ExternalEncoder, SentenceTransformer]
 class ContextualModel(ABC, TransformerMixin, BaseEstimator):
     """Base class for contextual topic models in Turftopic."""
 
-    def get_topics(self, top_k: int = 10) -> List[Tuple[Any, List[Tuple[str, float]]]]:
+    def get_topics(
+        self, top_k: int = 10
+    ) -> List[Tuple[Any, List[Tuple[str, float]]]]:
         """Returns high-level topic representations in form of the top K words
         in each topic.
 
@@ -135,8 +137,12 @@ class ContextualModel(ABC, TransformerMixin, BaseEstimator):
         except AttributeError:
             pass
         kth = min(top_k, document_topic_matrix.shape[0] - 1)
-        highest = np.argpartition(-document_topic_matrix[:, topic_id], kth)[:kth]
-        highest = highest[np.argsort(-document_topic_matrix[highest, topic_id])]
+        highest = np.argpartition(-document_topic_matrix[:, topic_id], kth)[
+            :kth
+        ]
+        highest = highest[
+            np.argsort(-document_topic_matrix[highest, topic_id])
+        ]
         scores = document_topic_matrix[highest, topic_id]
         columns = []
         columns.append("Document")
@@ -171,7 +177,9 @@ class ContextualModel(ABC, TransformerMixin, BaseEstimator):
             topic_id, raw_documents, document_topic_matrix, top_k
         )
         table = Table(show_lines=True)
-        table.add_column("Document", justify="left", style="magenta", max_width=100)
+        table.add_column(
+            "Document", justify="left", style="magenta", max_width=100
+        )
         table.add_column("Score", style="blue", justify="right")
         for row in rows:
             table.add_row(*row)
@@ -223,7 +231,9 @@ class ContextualModel(ABC, TransformerMixin, BaseEstimator):
     ) -> list[list[str]]:
         if topic_dist is None:
             if text is None:
-                raise ValueError("You should either pass a text or a distribution.")
+                raise ValueError(
+                    "You should either pass a text or a distribution."
+                )
             try:
                 topic_dist = self.transform([text])
             except AttributeError:
@@ -248,7 +258,9 @@ class ContextualModel(ABC, TransformerMixin, BaseEstimator):
             rows.append([topic_names[ind], f"{score:.2f}"])
         return [columns, *rows]
 
-    def print_topic_distribution(self, text=None, topic_dist=None, top_k: int = 10):
+    def print_topic_distribution(
+        self, text=None, topic_dist=None, top_k: int = 10
+    ):
         """Pretty prints topic distribution in a document.
 
         Parameters
@@ -330,7 +342,9 @@ class ContextualModel(ABC, TransformerMixin, BaseEstimator):
         """
         pass
 
-    def fit(self, raw_documents, y=None, embeddings: Optional[np.ndarray] = None):
+    def fit(
+        self, raw_documents, y=None, embeddings: Optional[np.ndarray] = None
+    ):
         """Fits model on the given corpus.
 
         Parameters
@@ -396,9 +410,13 @@ class ContextualModel(ABC, TransformerMixin, BaseEstimator):
         if embeddings is None:
             embeddings = self.encode_documents(corpus)
         try:
-            document_topic_matrix = self.transform(corpus, embeddings=embeddings)
+            document_topic_matrix = self.transform(
+                corpus, embeddings=embeddings
+            )
         except (AttributeError, NotFittedError):
-            document_topic_matrix = self.fit_transform(corpus, embeddings=embeddings)
+            document_topic_matrix = self.fit_transform(
+                corpus, embeddings=embeddings
+            )
         dtm = self.vectorizer.transform(corpus)  # type: ignore
         res: TopicData = {
             "corpus": corpus,

--- a/turftopic/dynamic.py
+++ b/turftopic/dynamic.py
@@ -199,7 +199,9 @@ class DynamicTopicModel(ABC):
         show_scores: bool, default False
             Indicates whether to show importance scores for each word.
         """
-        columns, *rows = self._topics_over_time(top_k, show_scores, date_format)
+        columns, *rows = self._topics_over_time(
+            top_k, show_scores, date_format
+        )
         table = Table(show_lines=True)
         for column in columns:
             table.add_column(column)

--- a/turftopic/encoders/__init__.py
+++ b/turftopic/encoders/__init__.py
@@ -9,5 +9,5 @@ __all__ = [
     "OpenAIEmbeddings",
     "VoyageEmbeddings",
     "ExternalEncoder",
-    "E5Encoder"
+    "E5Encoder",
 ]

--- a/turftopic/encoders/utils.py
+++ b/turftopic/encoders/utils.py
@@ -1,0 +1,12 @@
+import itertools
+from typing import Iterable, List
+
+
+def batched(iterable, n: int) -> Iterable[List[str]]:
+    "Batch data into tuples of length n. The last batch may be shorter."
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    if n < 1:
+        raise ValueError("n must be at least one")
+    it = iter(iterable)
+    while batch := list(itertools.islice(it, n)):
+        yield batch

--- a/turftopic/models/cluster.py
+++ b/turftopic/models/cluster.py
@@ -77,7 +77,7 @@ def calculate_topic_vectors(
     return centroids
 
 
-class ClusteringTopicModel(ContextualModel, ClusterMixin):
+class ClusteringTopicModel(ContextualModel, ClusterMixin, DynamicTopicModel):
     """Topic models, which assume topics to be clusters of documents
     in semantic space.
     Models also include a dimensionality reduction step to aid clustering.

--- a/turftopic/models/cluster.py
+++ b/turftopic/models/cluster.py
@@ -181,7 +181,6 @@ class ClusteringTopicModel(ContextualModel, ClusterMixin, DynamicTopicModel):
         self.feature_importance = feature_importance
         self.n_reduce_to = n_reduce_to
         self.reduction_method = reduction_method
-        self.components_ = None
 
     def _merge_agglomerative(self, n_reduce_to: int) -> np.ndarray:
         n_topics = self.components_.shape[0]
@@ -328,7 +327,7 @@ class ClusteringTopicModel(ContextualModel, ClusterMixin, DynamicTopicModel):
         if embeddings is None:
             embeddings = self.encoder_.encode(raw_documents)
         for i_timebin in np.arange(len(self.time_bin_edges) - 1):
-            if self.components_ is not None:
+            if hasattr(self, 'components_'):
                 doc_topic_matrix = label_binarize(
                     self.labels_, classes=self.classes_
                 )

--- a/turftopic/models/cluster.py
+++ b/turftopic/models/cluster.py
@@ -35,6 +35,10 @@ the desired reduced number on initialization.
 ClusteringTopicModel(n_reduce_to=10)
 """
 
+feature_message = """ 
+feature_importance must be one of 'soft-c-tf-idf', 'c-tf-idf', 'centroids'
+"""
+
 
 def smallest_hierarchical_join(
     topic_vectors: np.ndarray,
@@ -140,6 +144,10 @@ class ClusteringTopicModel(ContextualModel, ClusterMixin, DynamicTopicModel):
         reduction_method: Literal["agglomerative", "smallest"] = "agglomerative",
     ):
         self.encoder = encoder
+        if feature_importance not in ["c-tf-idf", 
+                                      "soft-c-tf-idf", 
+                                      "centroid"]:
+            raise ValueError(feature_message)
         if isinstance(encoder, int):
             raise TypeError(integer_message)
         if isinstance(encoder, str):

--- a/turftopic/models/decomp.py
+++ b/turftopic/models/decomp.py
@@ -47,6 +47,7 @@ class SemanticSignalSeparation(ContextualModel):
         ] = "sentence-transformers/all-MiniLM-L6-v2",
         vectorizer: Optional[CountVectorizer] = None,
         objective: Literal["orthogonality", "independence"] = "independence",
+        subset: str = None
     ):
         self.n_components = n_components
         self.encoder = encoder
@@ -63,6 +64,7 @@ class SemanticSignalSeparation(ContextualModel):
             self.decomposition = FastICA(n_components)
         else:
             self.decomposition = PCA(n_components)
+        self.subset = subset
 
     def fit_transform(
         self, raw_documents, y=None, embeddings: Optional[np.ndarray] = None
@@ -87,6 +89,12 @@ class SemanticSignalSeparation(ContextualModel):
             self.components_ = vocab_topic.T
             console.log("Model fitting done.")
         return doc_topic
+
+    def abs_components(self, subset):
+        if subset == 'abs':
+            self.components_ = np.abs(self.components_)
+        if subset == 'neg':
+            self.components_ = -self.components_
 
     def transform(
         self, raw_documents, embeddings: Optional[np.ndarray] = None

--- a/turftopic/models/decomp.py
+++ b/turftopic/models/decomp.py
@@ -47,7 +47,6 @@ class SemanticSignalSeparation(ContextualModel):
         ] = "sentence-transformers/all-MiniLM-L6-v2",
         vectorizer: Optional[CountVectorizer] = None,
         objective: Literal["orthogonality", "independence"] = "independence",
-        subset: str = None
     ):
         self.n_components = n_components
         self.encoder = encoder
@@ -64,7 +63,6 @@ class SemanticSignalSeparation(ContextualModel):
             self.decomposition = FastICA(n_components)
         else:
             self.decomposition = PCA(n_components)
-        self.subset = subset
 
     def fit_transform(
         self, raw_documents, y=None, embeddings: Optional[np.ndarray] = None
@@ -89,12 +87,6 @@ class SemanticSignalSeparation(ContextualModel):
             self.components_ = vocab_topic.T
             console.log("Model fitting done.")
         return doc_topic
-
-    def abs_components(self, subset):
-        if subset == 'abs':
-            self.components_ = np.abs(self.components_)
-        if subset == 'neg':
-            self.components_ = -self.components_
 
     def transform(
         self, raw_documents, embeddings: Optional[np.ndarray] = None

--- a/turftopic/models/gmm.py
+++ b/turftopic/models/gmm.py
@@ -101,7 +101,6 @@ class GMM(ContextualModel, DynamicTopicModel):
             self.gmm_ = make_pipeline(dimensionality_reduction, mixture)
         else:
             self.gmm_ = mixture
-        self.components_ = None
 
     def fit_transform(
         self, raw_documents, y=None, embeddings: Optional[np.ndarray] = None
@@ -163,7 +162,7 @@ class GMM(ContextualModel, DynamicTopicModel):
         bins: Union[int, list[datetime]] = 10,
     ):
         time_labels, self.time_bin_edges = bin_timestamps(timestamps, bins)
-        if self.components_ is not None:
+        if hasattr(self, 'components_'):
             doc_topic_matrix = self.transform(
                 raw_documents, embeddings=embeddings
             )

--- a/turftopic/models/gmm.py
+++ b/turftopic/models/gmm.py
@@ -64,7 +64,9 @@ class GMM(ContextualModel, DynamicTopicModel):
     def __init__(
         self,
         n_components: int,
-        encoder: Union[Encoder, str] = "sentence-transformers/all-MiniLM-L6-v2",
+        encoder: Union[
+            Encoder, str
+        ] = "sentence-transformers/all-MiniLM-L6-v2",
         vectorizer: Optional[CountVectorizer] = None,
         dimensionality_reduction: Optional[TransformerMixin] = None,
         weight_prior: Literal["dirichlet", "dirichlet_process", None] = None,
@@ -118,7 +120,9 @@ class GMM(ContextualModel, DynamicTopicModel):
             console.log("Mixture model fitted.")
             status.update("Estimating term importances.")
             document_topic_matrix = self.gmm_.predict_proba(embeddings)
-            self.components_ = soft_ctf_idf(document_topic_matrix, document_term_matrix)
+            self.components_ = soft_ctf_idf(
+                document_topic_matrix, document_term_matrix
+            )
             console.log("Model fitting done.")
         return document_topic_matrix
 
@@ -160,14 +164,20 @@ class GMM(ContextualModel, DynamicTopicModel):
     ):
         time_labels, self.time_bin_edges = bin_timestamps(timestamps, bins)
         if self.components_ is not None:
-            doc_topic_matrix = self.transform(raw_documents, embeddings=embeddings)
+            doc_topic_matrix = self.transform(
+                raw_documents, embeddings=embeddings
+            )
         else:
-            doc_topic_matrix = self.fit_transform(raw_documents, embeddings=embeddings)
+            doc_topic_matrix = self.fit_transform(
+                raw_documents, embeddings=embeddings
+            )
         document_term_matrix = self.vectorizer.transform(raw_documents)
         temporal_components = []
         temporal_importances = []
         for i_timebin in np.arange(len(self.time_bin_edges) - 1):
-            topic_importances = doc_topic_matrix[time_labels == i_timebin].sum(axis=0)
+            topic_importances = doc_topic_matrix[time_labels == i_timebin].sum(
+                axis=0
+            )
             # Normalizing
             topic_importances = topic_importances / topic_importances.sum()
             components = soft_ctf_idf(

--- a/turftopic/models/keynmf.py
+++ b/turftopic/models/keynmf.py
@@ -89,9 +89,9 @@ class KeyNMF(ContextualModel):
         ] = "sentence-transformers/all-MiniLM-L6-v2",
         vectorizer: Optional[CountVectorizer] = None,
         top_n: int = 25,
-        keyword_scope: str = 'document',
+        keyword_scope: str = "document",
     ):
-        if keyword_scope not in ['document', 'corpus']:
+        if keyword_scope not in ["document", "corpus"]:
             raise ValueError("keyword_scope must be 'document' or 'corpus'")
         self.n_components = n_components
         self.top_n = top_n
@@ -123,7 +123,7 @@ class KeyNMF(ContextualModel):
         for i in range(total):
             terms = document_term_matrix[i, :].todense()
             embedding = embeddings[i].reshape(1, -1)
-            if self.keyword_scope == 'document':
+            if self.keyword_scope == "document":
                 mask = terms > 0
             else:
                 tot_freq = document_term_matrix.sum(axis=0)


### PR DESCRIPTION
fixes #11

Need to:
- add `fit_transform_dynamic` to `ClusteringTopicModel`
- add tests for dynamic models

Still WIP and not tested, need to discuss what to do to compute temporal components when feature importance is based on distance from topic centroid, i.e.:
- are topic centroids computed based on all documents, or only documents present in a given time bin?
- what to do with terms that do not occur in the documents? set similarity to 0 or -1 for terms that do not occur within a given time bin, or use all terms?