### PR TITLE
fix ranking of negative documents

### DIFF
--- a/turftopic/base.py
+++ b/turftopic/base.py
@@ -217,6 +217,7 @@ class ContextualModel(ABC, TransformerMixin, BaseEstimator):
             lowest = lowest[
                 np.argsort(document_topic_matrix[lowest, topic_id])
             ]
+            lowest = lowest[::-1]
             scores = document_topic_matrix[lowest, topic_id]
             for document_id, score in zip(lowest, scores):
                 doc = raw_documents[document_id]


### PR DESCRIPTION
Hey there, using turftopic for some exploratory stuff and I realized that `print_representative_documents` appends the negative documents to the output table in ascending order, which is a bit confusing. This might fix it?