### PR TITLE
Keynmf fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length=79
 
 [tool.poetry]
 name = "turftopic"
-version = "0.4.0"
+version = "0.4.1"
 description = "Topic modeling with contextual representations from sentence transformers."
 authors = ["Márton Kardos <power.up1163@gmail.com>"]
 license = "MIT"

--- a/turftopic/models/keynmf.py
+++ b/turftopic/models/keynmf.py
@@ -196,10 +196,6 @@ class KeyNMF(ContextualModel, DynamicTopicModel):
             )
         console = Console()
         with console.status("Running KeyNMF") as status:
-            if embeddings is None:
-                status.update("Encoding documents")
-                embeddings = self.encode_documents(corpus)
-                console.log("Documents encoded.")
             if keywords is None:
                 status.update("Extracting keywords")
                 keywords = self.extract_keywords(corpus, embeddings=embeddings)


### PR DESCRIPTION
When no embeddings are passed to `prepare_topic_data`, but the keywords are passed, embeddings don't get computed erroneously