### PR TITLE
Fixed keyword pruning in KeyNMF

### DIFF
--- a/docs/KeyNMF.md
+++ b/docs/KeyNMF.md
@@ -75,7 +75,7 @@ A precomputed Keyword matrix can also be used to fit a model:
 
 ```python
 keyword_matrix = model.extract_keywords(corpus)
-model.fit(keywords=keyword_matrix)
+model.fit(None, keywords=keyword_matrix)
 ```
 
 ## Topic Discovery
@@ -106,7 +106,7 @@ model.fit(corpus, embeddings=embeddings)
 
 # Fitting with precomputed keyword matrix
 keyword_matrix = model.extract_keywords(corpus)
-model.fit(keywords=keyword_matrix)
+model.fit(None, keywords=keyword_matrix)
 ```
 
 ## Dynamic Topic Modeling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length=79
 
 [tool.poetry]
 name = "turftopic"
-version = "0.4.2"
+version = "0.4.3"
 description = "Topic modeling with contextual representations from sentence transformers."
 authors = ["Márton Kardos <power.up1163@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length=79
 
 [tool.poetry]
 name = "turftopic"
-version = "0.4.1"
+version = "0.4.2"
 description = "Topic modeling with contextual representations from sentence transformers."
 authors = ["Márton Kardos <power.up1163@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length=79
 
 [tool.poetry]
 name = "turftopic"
-version = "0.4.3"
+version = "0.4.4"
 description = "Topic modeling with contextual representations from sentence transformers."
 authors = ["Márton Kardos <power.up1163@gmail.com>"]
 license = "MIT"

--- a/turftopic/models/_keynmf.py
+++ b/turftopic/models/_keynmf.py
@@ -162,6 +162,7 @@ class KeywordNMF:
         if (self.top_n is None) or (self.top_n >= len(keywords)):
             return keywords
         words, similarities = zip(*keywords.items())
+        similarities = np.array(similarities)
         selected = np.argsort(-similarities)[: self.top_n]
         items = [(words[i], similarities[i]) for i in selected]
         return dict(items)

--- a/turftopic/models/_keynmf.py
+++ b/turftopic/models/_keynmf.py
@@ -162,7 +162,7 @@ class KeywordNMF:
         if (self.top_n is None) or (self.top_n >= len(keywords)):
             return keywords
         words, similarities = zip(*keywords.items())
-        selected = np.argsort(similarities)[: self.top_n]
+        selected = np.argsort(-similarities)[: self.top_n]
         items = [(words[i], similarities[i]) for i in selected]
         return dict(items)
 

--- a/turftopic/models/keynmf.py
+++ b/turftopic/models/keynmf.py
@@ -116,9 +116,30 @@ class KeyNMF(ContextualModel, DynamicTopicModel):
             Document-topic matrix.
         """
         topic_data = self.prepare_topic_data(
-            list(raw_documents), embeddings=embeddings, keywords=keywords
+            raw_documents, embeddings=embeddings, keywords=keywords
         )
         return topic_data["document_topic_matrix"]
+
+    def fit(
+        self,
+        raw_documents=None,
+        y=None,
+        embeddings: Optional[np.ndarray] = None,
+        keywords: Optional[list[dict[str, float]]] = None,
+    ) -> np.ndarray:
+        """Fits topic model and returns topic importances for documents.
+
+        Parameters
+        ----------
+        raw_documents: iterable of str, optional
+            Documents to fit the model on.
+        embeddings: ndarray of shape (n_documents, n_dimensions), optional
+            Precomputed document encodings.
+        keywords: list[dict[str, float]], optional
+            Precomputed keyword dictionaries.
+        """
+        self.fit_transform(raw_documents, y, embeddings, keywords)
+        return self
 
     def get_vocab(self) -> np.ndarray:
         return np.array(self.model.index_to_key)
@@ -151,7 +172,7 @@ class KeyNMF(ContextualModel, DynamicTopicModel):
             )
         if keywords is None:
             keywords = self.extract_keywords(
-                raw_documents, embeddings=embeddings
+                list(raw_documents), embeddings=embeddings
             )
         return self.model.transform(keywords)
 
@@ -200,7 +221,7 @@ class KeyNMF(ContextualModel, DynamicTopicModel):
                 status.update("Extracting keywords")
                 keywords = self.extract_keywords(corpus, embeddings=embeddings)
                 console.log("Keyword extraction done.")
-            if len(keywords) != len(corpus):
+            if (corpus is not None) and (len(keywords) != len(corpus)):
                 raise ValueError(
                     "length of keywords is not the same as length of the corpus"
                 )


### PR DESCRIPTION
KeyNMF was taking the lowest N keywords instead of top N when passed pre-computed keywords.