### PR TITLE
Fix `prepare_topic_data()` in KeyNMF.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length=79
 
 [tool.poetry]
 name = "turftopic"
-version = "0.4.4"
+version = "0.4.5"
 description = "Topic modeling with contextual representations from sentence transformers."
 authors = ["Márton Kardos <power.up1163@gmail.com>"]
 license = "MIT"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,13 +9,8 @@ import pytest
 from sentence_transformers import SentenceTransformer
 from sklearn.datasets import fetch_20newsgroups
 
-from turftopic import (
-    GMM,
-    AutoEncodingTopicModel,
-    ClusteringTopicModel,
-    KeyNMF,
-    SemanticSignalSeparation,
-)
+from turftopic import (GMM, AutoEncodingTopicModel, ClusteringTopicModel,
+                       KeyNMF, SemanticSignalSeparation)
 
 
 def batched(iterable, n: int):
@@ -133,3 +128,13 @@ def test_fit_online(model):
         with out_path.open("w") as out_file:
             out_file.write(table)
         df = pd.read_csv(out_path)
+
+
+@pytest.mark.parametrize("model", models)
+def test_prepare_topic_data(model):
+    topic_data = model.prepare_topic_data(texts, embeddings=embeddings)
+    for key, value in topic_data.items():
+        if value is None:
+            raise TypeError(
+                "None of the fields of prepare_topic_data should be None."
+            )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -134,7 +134,8 @@ def test_fit_online(model):
 def test_prepare_topic_data(model):
     topic_data = model.prepare_topic_data(texts, embeddings=embeddings)
     for key, value in topic_data.items():
+        # We allow transform() to be None for transductive models
+        if key == "transform":
+            continue
         if value is None:
-            raise TypeError(
-                "None of the fields of prepare_topic_data should be None."
-            )
+            raise TypeError(f"Field {key} is None in topic_data.")


### PR DESCRIPTION
I separated the functionality of `fit_transform()` and `prepare_topic_data()`, as `fit_transform()` shouldn't necessarily need embeddings when keywords are passed, but `topic_data` should always contain the embeddings, otherwise errors will happen when visualizing in `topicwizard`.

Also added a test to safeguard this behaviour.