### PR TITLE
Added FASTopic implementation with Turftopic API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,12 @@ torch = "^2.1.0"
 scipy = "^1.10.0"
 rich = "^13.6.0"
 pyro-ppl = { version = "^1.8.0", optional = true }
-torch = { version = "^2.0.0", optional = true }
 mkdocs = { version = "^1.5.2", optional = true }
 mkdocs-material = { version = "^9.5.12", optional = true }
 mkdocstrings = { version = "^0.24.0", extras = ["python"], optional = true }
 
 [tool.poetry.extras]
 pyro-ppl = ["pyro-ppl"]
-torch = ["torch"]
 docs = ["mkdocs", "mkdocs-material", "mkdocstrings"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,14 @@ torch = "^2.1.0"
 scipy = "^1.10.0"
 rich = "^13.6.0"
 pyro-ppl = { version = "^1.8.0", optional = true }
+torch = { version = "^2.0.0", optional = true }
 mkdocs = { version = "^1.5.2", optional = true }
 mkdocs-material = { version = "^9.5.12", optional = true }
 mkdocstrings = { version = "^0.24.0", extras = ["python"], optional = true }
 
 [tool.poetry.extras]
 pyro-ppl = ["pyro-ppl"]
+torch = ["torch"]
 docs = ["mkdocs", "mkdocs-material", "mkdocstrings"]
 
 [build-system]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,9 @@ import numpy as np
 import pandas as pd
 import pytest
 from sentence_transformers import SentenceTransformer
+from sklearn.cluster import KMeans
 from sklearn.datasets import fetch_20newsgroups
+from sklearn.decomposition import PCA
 
 from turftopic import (GMM, AutoEncodingTopicModel, ClusteringTopicModel,
                        FASTopic, KeyNMF, SemanticSignalSeparation)
@@ -50,43 +52,47 @@ embeddings = np.asarray(trf.encode(texts))
 timestamps = generate_dates(n_dates=len(texts))
 
 models = [
-    GMM(5, encoder=trf),
-    SemanticSignalSeparation(5, encoder=trf),
-    KeyNMF(5, encoder=trf),
+    GMM(3, encoder=trf),
+    SemanticSignalSeparation(3, encoder=trf),
+    KeyNMF(3, encoder=trf),
     ClusteringTopicModel(
-        n_reduce_to=5,
+        dimensionality_reduction=PCA(10),
+        clustering=KMeans(3),
         feature_importance="c-tf-idf",
         encoder=trf,
         reduction_method="agglomerative",
     ),
     ClusteringTopicModel(
-        n_reduce_to=5,
+        dimensionality_reduction=PCA(10),
+        clustering=KMeans(3),
         feature_importance="centroid",
         encoder=trf,
         reduction_method="smallest",
     ),
-    AutoEncodingTopicModel(5, combined=True),
-    FASTopic(5, batch_size=None),
+    AutoEncodingTopicModel(3, combined=True),
+    FASTopic(3, batch_size=None),
 ]
 
 dynamic_models = [
-    GMM(5, encoder=trf),
+    GMM(3, encoder=trf),
     ClusteringTopicModel(
-        n_reduce_to=5,
+        dimensionality_reduction=PCA(10),
+        clustering=KMeans(3),
         feature_importance="centroid",
         encoder=trf,
         reduction_method="smallest",
     ),
     ClusteringTopicModel(
-        n_reduce_to=5,
+        dimensionality_reduction=PCA(10),
+        clustering=KMeans(3),
         feature_importance="soft-c-tf-idf",
         encoder=trf,
         reduction_method="smallest",
     ),
-    KeyNMF(5, encoder=trf),
+    KeyNMF(3, encoder=trf),
 ]
 
-online_models = [KeyNMF(5, encoder=trf)]
+online_models = [KeyNMF(3, encoder=trf)]
 
 
 @pytest.mark.parametrize("model", models)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,7 @@ from sentence_transformers import SentenceTransformer
 from sklearn.datasets import fetch_20newsgroups
 
 from turftopic import (GMM, AutoEncodingTopicModel, ClusteringTopicModel,
-                       KeyNMF, SemanticSignalSeparation)
+                       FASTopic, KeyNMF, SemanticSignalSeparation)
 
 
 def batched(iterable, n: int):
@@ -66,6 +66,7 @@ models = [
         reduction_method="smallest",
     ),
     AutoEncodingTopicModel(5, combined=True),
+    FASTopic(5, batch_size=None),
 ]
 
 dynamic_models = [

--- a/turftopic/__init__.py
+++ b/turftopic/__init__.py
@@ -10,6 +10,11 @@ try:
 except ModuleNotFoundError:
     AutoEncodingTopicModel = NotInstalled("AutoEncodingTopicModel", "pyro-ppl")
 
+try:
+    from turftopic.models.fastopic import FASTopic
+except ModuleNotFoundError:
+    FASTopic = NotInstalled("FASTopic", "torch")
+
 __all__ = [
     "ClusteringTopicModel",
     "SemanticSignalSeparation",
@@ -17,4 +22,5 @@ __all__ = [
     "KeyNMF",
     "AutoEncodingTopicModel",
     "ContextualModel",
+    "FASTopic",
 ]

--- a/turftopic/models/_fastopic.py
+++ b/turftopic/models/_fastopic.py
@@ -81,11 +81,11 @@ class fastopic(nn.Module):
         self.DT_alpha = DT_alpha
         self.TW_alpha = TW_alpha
         self.theta_temp = theta_temp
-        seed = self.random_state or random.randint(0, 10_000)
-        torch.manual_seed(seed)
+        self.seed = random_state or random.randint(0, 10_000)
         self.epsilon = 1e-12
 
     def init(self, vocab_size: int, embed_size: int):
+        torch.manual_seed(self.seed)
         self.word_embeddings = nn.init.trunc_normal_(
             torch.empty(vocab_size, embed_size)
         )
@@ -108,6 +108,7 @@ class fastopic(nn.Module):
         self,
         doc_embeddings,
     ):
+        torch.manual_seed(self.seed)
         topic_embeddings = self.topic_embeddings.detach().to(
             doc_embeddings.device
         )
@@ -116,6 +117,7 @@ class fastopic(nn.Module):
 
     # only for testing
     def get_beta(self):
+        torch.manual_seed(self.seed)
         _, transp_TW = self.TW_ETP(self.topic_embeddings, self.word_embeddings)
         # use transport plan as beta
         beta = transp_TW * transp_TW.shape[0]
@@ -123,6 +125,7 @@ class fastopic(nn.Module):
 
     # only for testing
     def get_theta(self, doc_embeddings, train_doc_embeddings):
+        torch.manual_seed(self.seed)
         topic_embeddings = self.topic_embeddings.detach().to(
             doc_embeddings.device
         )
@@ -137,6 +140,7 @@ class fastopic(nn.Module):
         return theta
 
     def forward(self, train_bow, doc_embeddings):
+        torch.manual_seed(self.seed)
         loss_DT, transp_DT = self.DT_ETP(doc_embeddings, self.topic_embeddings)
         loss_TW, transp_TW = self.TW_ETP(
             self.topic_embeddings, self.word_embeddings

--- a/turftopic/models/_fastopic.py
+++ b/turftopic/models/_fastopic.py
@@ -1,0 +1,156 @@
+import random
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+def pairwise_euclidean_distance(x, y):
+    cost = (
+        torch.sum(x**2, axis=1, keepdim=True)
+        + torch.sum(y**2, dim=1)
+        - 2 * torch.matmul(x, y.t())
+    )
+    return cost
+
+
+class ETP(nn.Module):
+    def __init__(
+        self,
+        sinkhorn_alpha,
+        init_a_dist=None,
+        init_b_dist=None,
+        OT_max_iter=5000,
+        stopThr=0.5e-2,
+    ):
+        super().__init__()
+        self.sinkhorn_alpha = sinkhorn_alpha
+        self.OT_max_iter = OT_max_iter
+        self.stopThr = stopThr
+        self.epsilon = 1e-16
+        self.init_a_dist = init_a_dist
+        self.init_b_dist = init_b_dist
+        if init_a_dist is not None:
+            self.a_dist = init_a_dist
+        if init_b_dist is not None:
+            self.b_dist = init_b_dist
+
+    def forward(self, x, y):
+        # Sinkhorn's algorithm
+        M = pairwise_euclidean_distance(x, y)
+        device = M.device
+        if self.init_a_dist is None:
+            a = (torch.ones(M.shape[0]) / M.shape[0]).unsqueeze(1).to(device)
+        else:
+            a = F.softmax(self.a_dist, dim=0).to(device)
+        if self.init_b_dist is None:
+            b = (torch.ones(M.shape[1]) / M.shape[1]).unsqueeze(1).to(device)
+        else:
+            b = F.softmax(self.b_dist, dim=0).to(device)
+        u = (torch.ones_like(a) / a.size()[0]).to(device)  # Kx1
+        K = torch.exp(-M * self.sinkhorn_alpha)
+        err = 1
+        cpt = 0
+        while err > self.stopThr and cpt < self.OT_max_iter:
+            v = torch.div(b, torch.matmul(K.t(), u) + self.epsilon)
+            u = torch.div(a, torch.matmul(K, v) + self.epsilon)
+            cpt += 1
+            if cpt % 50 == 1:
+                bb = torch.mul(v, torch.matmul(K.t(), u))
+                err = torch.norm(
+                    torch.sum(torch.abs(bb - b), dim=0), p=float("inf")
+                )
+        transp = u * (K * v.T)
+        loss_ETP = torch.sum(transp * M)
+        return loss_ETP, transp
+
+
+class fastopic(nn.Module):
+    def __init__(
+        self,
+        num_topics: int,
+        theta_temp: float = 1.0,
+        DT_alpha: float = 3.0,
+        TW_alpha: float = 2.0,
+        random_state: Optional[int] = None,
+    ):
+        super().__init__()
+
+        self.num_topics = num_topics
+        self.DT_alpha = DT_alpha
+        self.TW_alpha = TW_alpha
+        self.theta_temp = theta_temp
+        seed = self.random_state or random.randint(0, 10_000)
+        torch.manual_seed(seed)
+        self.epsilon = 1e-12
+
+    def init(self, vocab_size: int, embed_size: int):
+        self.word_embeddings = nn.init.trunc_normal_(
+            torch.empty(vocab_size, embed_size)
+        )
+        self.word_embeddings = nn.Parameter(F.normalize(self.word_embeddings))
+        self.topic_embeddings = torch.empty((self.num_topics, embed_size))
+        nn.init.trunc_normal_(self.topic_embeddings, std=0.1)
+        self.topic_embeddings = nn.Parameter(
+            F.normalize(self.topic_embeddings)
+        )
+        self.word_weights = nn.Parameter(
+            (torch.ones(vocab_size) / vocab_size).unsqueeze(1)
+        )
+        self.topic_weights = nn.Parameter(
+            (torch.ones(self.num_topics) / self.num_topics).unsqueeze(1)
+        )
+        self.DT_ETP = ETP(self.DT_alpha, init_b_dist=self.topic_weights)
+        self.TW_ETP = ETP(self.TW_alpha, init_b_dist=self.word_weights)
+
+    def get_transp_DT(
+        self,
+        doc_embeddings,
+    ):
+        topic_embeddings = self.topic_embeddings.detach().to(
+            doc_embeddings.device
+        )
+        _, transp = self.DT_ETP(doc_embeddings, topic_embeddings)
+        return transp.detach().cpu().numpy()
+
+    # only for testing
+    def get_beta(self):
+        _, transp_TW = self.TW_ETP(self.topic_embeddings, self.word_embeddings)
+        # use transport plan as beta
+        beta = transp_TW * transp_TW.shape[0]
+        return beta
+
+    # only for testing
+    def get_theta(self, doc_embeddings, train_doc_embeddings):
+        topic_embeddings = self.topic_embeddings.detach().to(
+            doc_embeddings.device
+        )
+        dist = pairwise_euclidean_distance(doc_embeddings, topic_embeddings)
+        train_dist = pairwise_euclidean_distance(
+            train_doc_embeddings, topic_embeddings
+        )
+        exp_dist = torch.exp(-dist / self.theta_temp)
+        exp_train_dist = torch.exp(-train_dist / self.theta_temp)
+        theta = exp_dist / (exp_train_dist.sum(0))
+        theta = theta / theta.sum(1, keepdim=True)
+        return theta
+
+    def forward(self, train_bow, doc_embeddings):
+        loss_DT, transp_DT = self.DT_ETP(doc_embeddings, self.topic_embeddings)
+        loss_TW, transp_TW = self.TW_ETP(
+            self.topic_embeddings, self.word_embeddings
+        )
+        loss_ETP = loss_DT + loss_TW
+        theta = transp_DT * transp_DT.shape[0]
+        beta = transp_TW * transp_TW.shape[0]
+        # Dual Semantic-relation Reconstruction
+        recon = torch.matmul(theta, beta)
+        loss_DSR = (
+            -(train_bow * (recon + self.epsilon).log()).sum(axis=1).mean()
+        )
+        loss = loss_DSR + loss_ETP
+        rst_dict = {
+            "loss": loss,
+        }
+        return rst_dict

--- a/turftopic/models/fastopic.py
+++ b/turftopic/models/fastopic.py
@@ -1,0 +1,148 @@
+import math
+from typing import Optional, Union
+
+import numpy as np
+import torch
+from rich.console import Console
+from sentence_transformers import SentenceTransformer
+from sklearn.feature_extraction.text import CountVectorizer
+
+from turftopic.base import ContextualModel, Encoder
+from turftopic.models._fastopic import fastopic
+from turftopic.vectorizer import default_vectorizer
+
+
+class FASTopic(ContextualModel):
+    def __init__(
+        self,
+        n_components: int,
+        encoder: Union[
+            Encoder, str
+        ] = "sentence-transformers/all-MiniLM-L6-v2",
+        vectorizer: Optional[CountVectorizer] = None,
+        random_state: Optional[int] = None,
+        batch_size: Optional[int] = None,
+        DT_alpha: float = 3.0,
+        TW_alpha: float = 2.0,
+        theta_temp: float = 1.0,
+        n_epochs: int = 200,
+        learning_rate: float = 0.002,
+        device: str = None,
+    ):
+        self.n_components = n_components
+        self.encoder = encoder
+        self.random_state = random_state
+        if isinstance(encoder, str):
+            self.encoder_ = SentenceTransformer(encoder)
+        else:
+            self.encoder_ = encoder
+        if vectorizer is None:
+            self.vectorizer = default_vectorizer()
+        else:
+            self.vectorizer = vectorizer
+        self.DT_alpha = DT_alpha
+        self.TW_alpha = TW_alpha
+        self.theta_temp = theta_temp
+        self.n_epochs = n_epochs
+        self.learning_rate = learning_rate
+        self.device = device
+        self.model = fastopic(n_components, theta_temp, DT_alpha, TW_alpha)
+        self.batch_size = batch_size
+
+    def make_optimizer(self, learning_rate: float):
+        args_dict = {
+            "params": self.model.parameters(),
+            "lr": learning_rate,
+        }
+        optimizer = torch.optim.Adam(**args_dict)
+        return optimizer
+
+    def _train_model(self, embeddings, document_term_matrix, status):
+        self.model.init(document_term_matrix.shape[1], embeddings.shape[1])
+        self.model = self.model.to(self.device)
+        optimizer = self.make_optimizer(self.learning_rate)
+        self.model.train()
+        if self.batch_size is None:
+            batch_size = embeddings.shape[0]
+        else:
+            batch_size = self.batch_size
+        num_batches = int(
+            math.ceil(document_term_matrix.shape[0] / batch_size)
+        )
+        for epoch in range(self.n_epochs):
+            running_loss = 0
+            for i in range(num_batches):
+                batch_bow = np.atleast_2d(
+                    document_term_matrix[
+                        i * batch_size : (i + 1) * batch_size, :
+                    ].toarray()
+                )
+                # Skipping batches that are smaller than 2
+                if batch_bow.shape[0] < 2:
+                    continue
+                batch_contextualized = np.atleast_2d(
+                    embeddings[i * batch_size : (i + 1) * batch_size, :]
+                )
+                batch_contextualized = (
+                    torch.tensor(batch_contextualized).float().to(self.device)
+                )
+                batch_bow = torch.tensor(batch_bow).float().to(self.device)
+                rst_dict = self.model(batch_bow, batch_contextualized)
+                batch_loss = rst_dict["loss"]
+                running_loss += batch_loss
+                optimizer.zero_grad()
+                batch_loss.backward()
+                optimizer.step()
+            status.update(
+                f"Fitting model. Epoch [{epoch}/{self.n_epochs}], Loss [{running_loss}]"
+            )
+        self.components_ = self.model.get_beta().detach().numpy()
+
+    def fit_transform(
+        self, raw_documents, y=None, embeddings: Optional[np.ndarray] = None
+    ) -> np.ndarray:
+        console = Console()
+        with console.status("Fitting model") as status:
+            if embeddings is None:
+                status.update("Encoding documents")
+                embeddings = self.encoder_.encode(raw_documents)
+                console.log("Documents encoded.")
+            self.train_doc_embeddings = embeddings
+            status.update("Extracting terms.")
+            document_term_matrix = self.vectorizer.fit_transform(raw_documents)
+            console.log("Term extraction done.")
+            status.update("Fitting model")
+            self._train_model(embeddings, document_term_matrix, status)
+            console.log("Model fitting done.")
+            document_topic_matrix = self.transform(
+                raw_documents, embeddings=embeddings
+            )
+        return document_topic_matrix
+
+    def transform(
+        self, raw_documents, embeddings: Optional[np.ndarray] = None
+    ) -> np.ndarray:
+        """Infers topic importances for new documents based on a fitted model.
+
+        Parameters
+        ----------
+        raw_documents: iterable of str
+            Documents to fit the model on.
+        embeddings: ndarray of shape (n_documents, n_dimensions), optional
+            Precomputed document encodings.
+
+        Returns
+        -------
+        ndarray of shape (n_dimensions, n_topics)
+            Document-topic matrix.
+        """
+        if embeddings is None:
+            embeddings = self.encoder_.encode(raw_documents)
+        with torch.no_grad():
+            self.model.eval()
+            theta = self.model.get_theta(
+                torch.as_tensor(embeddings),
+                torch.as_tensor(self.train_doc_embeddings),
+            )
+            theta = theta.detach().cpu().numpy()
+        return theta

--- a/turftopic/models/fastopic.py
+++ b/turftopic/models/fastopic.py
@@ -13,6 +13,54 @@ from turftopic.vectorizer import default_vectorizer
 
 
 class FASTopic(ContextualModel):
+    """
+    Implementation of the FASTopic model with a Turftopic API.
+    The implementation is based on the [original FASTopic package](https://github.com/BobXWu/FASTopic/tree/master),
+    but is adapted for optimal use in Turftopic (you can pre-compute embeddings for instance).
+
+    You will need to install torch to use this model.
+
+    ```bash
+    pip install turftopic[torch]
+    ## OR:
+    pip install turftopic[pyro-ppl]
+    ```
+
+    ```python
+    from turftopic import FASTopic
+
+    corpus: list[str] = ["some text", "more text", ...]
+
+    model = FASTopic(10).fit(corpus)
+    model.print_topics()
+    ```
+
+    Parameters
+    ----------
+    n_components: int
+        Number of topics. If you're using priors on the weight,
+        feel free to overshoot with this value.
+    encoder: str or SentenceTransformer
+        Model to encode documents/terms, all-MiniLM-L6-v2 is the default.
+    vectorizer: CountVectorizer, default None
+        Vectorizer used for term extraction.
+        Can be used to prune or filter the vocabulary.
+    random_state: int, default None
+        Random state to use so that results are exactly reproducible.
+    DT_alpha: float, default 3.0
+        Sinkhorn alpha between document embeddings and topic embeddings.
+    TW_alpha: float, default 2.0
+        Sinkhorn alpha between topic embeddings and word embeddings.
+    theta_temp: float, default 1.0
+        Temperature parameter of used in softmax to compute topic probabilities in documents.
+    n_epochs: int, default 200
+        Number of epochs to train the model for.
+    learning_rate: float, default 0.002
+        Learning rate for the ADAM optimizer.
+    device: str, default "cpu"
+        Device to run the model on. Defaults to CPU.
+    """
+
     def __init__(
         self,
         n_components: int,
@@ -27,7 +75,7 @@ class FASTopic(ContextualModel):
         theta_temp: float = 1.0,
         n_epochs: int = 200,
         learning_rate: float = 0.002,
-        device: str = None,
+        device: str = "cpu",
     ):
         self.n_components = n_components
         self.encoder = encoder


### PR DESCRIPTION
FASTopic has been added to the library with minor changes to the original implementation.

```bash
pip install turftopic[torch]
```

```python
from turftopic import FASTopic

model = FASTopic(10)
model.fit(corpus)

model.print_topics()
```