### PR TITLE
CTM hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length=79
 
 [tool.poetry]
 name = "turftopic"
-version = "0.5.3"
+version = "0.5.4"
 description = "Topic modeling with contextual representations from sentence transformers."
 authors = ["Márton Kardos <power.up1163@gmail.com>"]
 license = "MIT"

--- a/turftopic/models/ctm.py
+++ b/turftopic/models/ctm.py
@@ -213,9 +213,7 @@ class AutoEncodingTopicModel(ContextualModel):
             seed = self.random_state or random.randint(0, 10_000)
             torch.manual_seed(seed)
             pyro.set_rng_seed(seed)
-            device = torch.device(
-                "cuda:0" if torch.cuda.is_available() else "cpu"
-            )
+            device = torch.device("cpu")
             pyro.clear_param_store()
             contextualized_size = embeddings.shape[1]
             if self.combined:


### PR DESCRIPTION
CTMs did not work on machines with GPUs as they put some arrays in GPU memory while kept others in CPU memory.
I will try to fix this in the future and add a device argument, but for now, everything is locked to the CPU.