### PR TITLE
Added feature importance methods based on cluster differences

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -121,11 +121,11 @@ By and large there are two types of methods that can be used for importance esti
 
 | Importance method | Type | Description | Advantages |
 | - | - | - | - |
-| `linear` **(NEW)** | Semantic | Project words onto the parameter vectors of a linear classifier (LDA). | Topic differences are measured in embedding space and are determined by predictive power, and are therefore accurate and clean. |
-| `fighting-words` **(NEW)** | Lexical | Compute word importance based on cluster differences using the Fightin' Words algorithm by Monroe et al. | A theoretically motivated probabilistic model that was explicitly designed for discovering lexical differences in groups of text. |
-| `c-tf-idf` | Lexical | Compute how unique terms are in a cluster with a tf-idf style weighting scheme. This is the default in BERTopic. | Very fast, easy to understand and is not affected by cluster shape. |
 | `soft-c-tf-idf` *(default)* | Lexical | A c-tf-idf mehod that can interpret soft cluster assignments. | Can interpret soft cluster assignment in models like Gaussian Mixtures, less sensitive to stop words than vanilla c-tf-idf. |
+| `fighting-words` **(NEW)** | Lexical | Compute word importance based on cluster differences using the Fightin' Words algorithm by Monroe et al. | A theoretically motivated probabilistic model that was explicitly designed for discovering lexical differences in groups of text. See [Fightin' Words paper](https://languagelog.ldc.upenn.edu/myl/Monroe.pdf). |
+| `c-tf-idf` | Lexical | Compute how unique terms are in a cluster with a tf-idf style weighting scheme. This is the default in BERTopic. | Very fast, easy to understand and is not affected by cluster shape. |
 | `centroid` | Semantic | Word importance based on words' proximity to cluster centroid vectors. This is the default in Top2Vec. | Produces clean topics, easily interpretable. |
+| `linear` **(NEW, EXPERIMENTAL)** | Semantic | Project words onto the parameter vectors of a linear classifier (LDA). | Topic differences are measured in embedding space and are determined by predictive power, and are therefore accurate and clean. |
 
 
 !!! quote "Choose a term importance estimation method"
@@ -139,6 +139,30 @@ By and large there are two types of methods that can be used for importance esti
         # or
         model = ClusteringTopicModel(feature_importance="c-tf-idf")
         ```
+
+         ??? info "Click to see formulas"
+            #### Soft-c-TF-IDF
+            - Let $X$ be the document term matrix where each element ($X_{ij}$) corresponds with the number of times word $j$ occurs in a document $i$.
+            - Estimate weight of term $j$ for topic $z$: <br>
+            $tf_{zj} = \frac{t_{zj}}{w_z}$, where 
+            $t_{zj} = \sum_{i \in z} X_{ij}$ is the number of occurrences of a word in a topic and 
+            $w_{z}= \sum_{j} t_{zj}$ is all words in the topic <br>
+            - Estimate inverse document/topic frequency for term $j$:  
+            $idf_j = log(\frac{N}{\sum_z |t_{zj}|})$, where
+            $N$ is the total number of documents.
+            - Calculate importance of term $j$ for topic $z$:   
+            $Soft-c-TF-IDF{zj} = tf_{zj} \cdot idf_j$
+
+            #### c-TF-IDF
+            - Let $X$ be the document term matrix where each element ($X_{ij}$) corresponds with the number of times word $j$ occurs in a document $i$.
+            - $tf_{zj} = \frac{t_{zj}}{w_z}$, where 
+            $t_{zj} = \sum_{i \in z} X_{ij}$ is the number of occurrences of a word in a topic and 
+            $w_{z}= \sum_{j} t_{zj}$ is all words in the topic <br>
+            - Estimate inverse document/topic frequency for term $j$:  
+            $idf_j = log(1 + \frac{A}{\sum_z |t_{zj}|})$, where
+            $A = \frac{\sum_z \sum_j t_{zj}}{Z}$ is the average number of words per topic, and $Z$ is the number of topics.
+            - Calculate importance of term $j$ for topic $z$:   
+            $c-TF-IDF{zj} = tf_{zj} \cdot idf_j$
 
     === "Centroid Proximity (Top2Vec)"
 

--- a/turftopic/feature_importance.py
+++ b/turftopic/feature_importance.py
@@ -5,10 +5,7 @@ from typing import Literal
 import numpy as np
 import scipy.sparse as spr
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
-from sklearn.feature_extraction.text import TfidfTransformer
 from sklearn.metrics.pairwise import cosine_similarity
-from sklearn.preprocessing import normalize
-from sklearn.utils import check_array
 
 
 def cluster_centroid_distance(

--- a/turftopic/feature_importance.py
+++ b/turftopic/feature_importance.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Literal
+
 import numpy as np
 import scipy.sparse as spr
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
@@ -43,7 +47,7 @@ def linear_classifier(
     vocab_embeddings: np.ndarray,
 ) -> np.ndarray:
     """Computes feature importances based on embedding directions
-    obtained with logistic regression.
+    obtained with a linear classifier.
 
     Parameters
     ----------
@@ -66,6 +70,60 @@ def linear_classifier(
         # Binary is a special case
         components = np.concatenate([-components, components], axis=0)
     return components
+
+
+def fighting_words(
+    doc_topic_matrix: np.ndarray,
+    doc_term_matrix: spr.csr_matrix,
+    prior: float | Literal["corpus"] = "corpus",
+) -> np.ndarray:
+    """Computes feature importance using the *Fighting Words* algorithm.
+
+    Parameters
+    ----------
+    doc_topic_matrix: np.ndarray
+        Document-topic matrix of shape (n_documents, n_topics)
+    doc_term_matrix: np.ndarray
+        Document-term matrix of shape (n_documents, vocab_size)
+    prior: float or "corpus", default "corpus"
+        Dirichlet prior to use. When a float, it indicates the alpha
+        parameter of a symmetric Dirichlet, if "corpus",
+        word frequencies from the background corpus are used.
+
+    Returns
+    -------
+    ndarray of shape (n_topics, vocab_size)
+        Term importance matrix.
+    """
+    labels = np.argmax(doc_topic_matrix, axis=1)
+    n_topics = doc_topic_matrix.shape[1]
+    n_vocab = doc_term_matrix.shape[1]
+    components = []
+    if prior == "corpus":
+        priors = np.ravel(np.asarray(doc_term_matrix.sum(axis=0)))
+    else:
+        priors = np.full(n_vocab, prior)
+    a0 = np.sum(priors)  # prior * n_vocab
+    for i_topic in range(n_topics):
+        topic_freq = np.ravel(
+            np.asarray(doc_term_matrix[labels == i_topic].sum(axis=0))
+        )
+        rest_freq = np.ravel(
+            np.asarray(doc_term_matrix[labels != i_topic].sum(axis=0))
+        )
+        n1 = np.sum(topic_freq)
+        n2 = np.sum(rest_freq)
+        topic_logodds = np.log(
+            (topic_freq + priors) / (n1 + a0 - topic_freq - priors)
+        )
+        rest_logodds = np.log(
+            (rest_freq + priors) / (n2 + a0 - rest_freq - priors)
+        )
+        delta = topic_logodds - rest_logodds
+        delta_var = 1 / (topic_freq + priors) + 1 / (rest_freq + priors)
+        zscore = delta / np.sqrt(delta_var)
+        components.append(zscore)
+    return np.stack(components)
 
 
 def soft_ctf_idf(

--- a/turftopic/feature_importance.py
+++ b/turftopic/feature_importance.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.sparse as spr
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.feature_extraction.text import TfidfTransformer
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.preprocessing import normalize
@@ -33,6 +34,37 @@ def cluster_centroid_distance(
         cluster_centroids[valid_centroids], vocab_embeddings
     )
     components[valid_centroids, :] = similarities
+    return components
+
+
+def linear_classifier(
+    doc_topic_matrix: np.ndarray,
+    embeddings: np.ndarray,
+    vocab_embeddings: np.ndarray,
+) -> np.ndarray:
+    """Computes feature importances based on embedding directions
+    obtained with logistic regression.
+
+    Parameters
+    ----------
+    doc_topic_matrix: np.ndarray
+        Document-topic matrix.
+    embeddings: np.ndarray
+        Document embeddings.
+    vocab_embeddings: np.ndarray
+        Term embeddings of shape (vocab_size, embedding_size)
+
+    Returns
+    -------
+    ndarray of shape (n_topics, vocab_size)
+        Term importance matrix.
+    """
+    labels = np.argmax(doc_topic_matrix, axis=1)
+    model = LinearDiscriminantAnalysis().fit(embeddings, labels)
+    components = cosine_similarity(model.coef_, vocab_embeddings)
+    if len(set(labels)) == 2:
+        # Binary is a special case
+        components = np.concatenate([-components, components], axis=0)
     return components
 
 

--- a/turftopic/models/cluster.py
+++ b/turftopic/models/cluster.py
@@ -33,7 +33,12 @@ from turftopic.models._hierarchical_clusters import (
     ClusterNode,
     LinkageMethod,
 )
-from turftopic.multimodal import Image, ImageRepr, MultimodalEmbeddings, MultimodalModel
+from turftopic.multimodal import (
+    Image,
+    ImageRepr,
+    MultimodalEmbeddings,
+    MultimodalModel,
+)
 from turftopic.types import VALID_DISTANCE_METRICS, DistanceMetric
 from turftopic.utils import safe_binarize
 from turftopic.vectorizers.default import default_vectorizer
@@ -453,7 +458,8 @@ class ClusteringTopicModel(
         raw_documents: iterable of str
             Documents to fit the model on.
         y: None
-            Originally ignored, in case of a dimensionality reduction that can utilize labels,
+            Ignored, when the dimensionality reduction is TSNE (the default),
+            in case of a dimensionality reduction that can utilize labels,
             you can pass labels to the model to inform the clustering process.
         embeddings: ndarray of shape (n_documents, n_dimensions), optional
             Precomputed document encodings.

--- a/turftopic/models/decomp.py
+++ b/turftopic/models/decomp.py
@@ -140,7 +140,11 @@ class SemanticSignalSeparation(
                 self.embeddings = self.encoder_.encode(raw_documents)
                 console.log("Documents encoded.")
             status.update("Decomposing embeddings")
-            doc_topic = self.decomposition.fit_transform(self.embeddings)
+            if isinstance(self.decomposition, FastICA) and (y is not None):
+                warnings.warn(
+                    "Supervisory signal is specified but decomposition method is FastICA. y will be ignored. Use a metric learning method for supervised S^3."
+                )
+            doc_topic = self.decomposition.fit_transform(self.embeddings, y=y)
             console.log("Decomposition done.")
             status.update("Extracting terms.")
             vocab = self.vectorizer.fit(raw_documents).get_feature_names_out()
@@ -190,7 +194,11 @@ class SemanticSignalSeparation(
                 console.log("Documents encoded.")
             self.embeddings = self.multimodal_embeddings["document_embeddings"]
             status.update("Decomposing embeddings")
-            doc_topic = self.decomposition.fit_transform(self.embeddings)
+            if isinstance(self.decomposition, FastICA) and (y is not None):
+                warnings.warn(
+                    "Supervisory signal is specified but decomposition method is FastICA. y will be ignored. Use a metric learning method for supervised S^3."
+                )
+            doc_topic = self.decomposition.fit_transform(self.embeddings, y=y)
             console.log("Decomposition done.")
             status.update("Extracting terms.")
             vocab = self.vectorizer.fit(raw_documents).get_feature_names_out()

--- a/turftopic/models/decomp.py
+++ b/turftopic/models/decomp.py
@@ -16,7 +16,11 @@ from sklearn.metrics.pairwise import cosine_similarity, euclidean_distances
 from turftopic.base import ContextualModel, Encoder
 from turftopic.dynamic import DynamicTopicModel
 from turftopic.encoders.multimodal import MultimodalEncoder
-from turftopic.multimodal import ImageRepr, MultimodalEmbeddings, MultimodalModel
+from turftopic.multimodal import (
+    ImageRepr,
+    MultimodalEmbeddings,
+    MultimodalModel,
+)
 from turftopic.namers.base import TopicNamer
 from turftopic.vectorizers.default import default_vectorizer
 
@@ -142,7 +146,7 @@ class SemanticSignalSeparation(
             status.update("Decomposing embeddings")
             if isinstance(self.decomposition, FastICA) and (y is not None):
                 warnings.warn(
-                    "Supervisory signal is specified but decomposition method is FastICA. y will be ignored. Use a metric learning method for supervised S^3."
+                    "y is specified but decomposition method is FastICA, which can't use labels. y will be ignored. Use a metric learning method for semi-supervised S^3."
                 )
             doc_topic = self.decomposition.fit_transform(self.embeddings, y=y)
             console.log("Decomposition done.")


### PR DESCRIPTION
I already started working on a fighting-words based feature importance estimation method here: #75 
Since then I have found a better method for measuring semantic difference between clusters based on linear classifiers.
I decided to use LinearDiscrimantAnalysis since it is orders of magnitudes faster than other methods, and it takes forever to estimate feature importance for each of the levels of the hierarchy otherwise when reducing the number of topics.

I am also planning to add supervised topic modelling based on these feature importance methods in the near future.